### PR TITLE
fix: error in markdown/yml format

### DIFF
--- a/docs/decisions/adr-template.md
+++ b/docs/decisions/adr-template.md
@@ -1,10 +1,10 @@
 ---
 # These are optional elements. Feel free to remove any of them.
-status: {proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)}
-date: {YYYY-MM-DD when the decision was last updated}
-deciders: {list everyone involved in the decision}
-consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
-informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
+status: proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)
+date: YYYY-MM-DD when the decision was last updated
+deciders: list everyone involved in the decision
+consulted: list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication
+informed: list everyone who is kept up-to-date on progress; and with whom there is a one-way communication
 ---
 # {short title of solved problem and solution}
 


### PR DESCRIPTION
When I try to build this into the atsite repo, Nuxt complains about incorrect format, which is messing up the documentation pages.

Github also complains if you visit the page directly - https://github.com/agritheory/cloud_storage/blob/version-14/docs/decisions/adr-template.md.