### PR TITLE
fix: only add file associations if full attachment info is available

### DIFF
--- a/cloud_storage/cloud_storage/overrides/file.py
+++ b/cloud_storage/cloud_storage/overrides/file.py
@@ -84,19 +84,19 @@ class CustomFile(File):
 			# if a File exists already where this association should be, we continue validating that File at this time
 			# the original File will then be removed in the after insert hook
 			self = existing_file
-
-		existing_attachment = list(
-			filter(
-				lambda row: row.link_doctype == self.attached_to_doctype
-				and row.link_name == self.attached_to_name,
-				self.file_association,
+		if self.attached_to_doctype and self.attached_to_name:
+			existing_attachment = list(
+				filter(
+					lambda row: row.link_doctype == self.attached_to_doctype
+					and row.link_name == self.attached_to_name,
+					self.file_association,
+				)
 			)
-		)
-		if not existing_attachment:
-			self.append(
-				"file_association",
-				{"link_doctype": self.attached_to_doctype, "link_name": self.attached_to_name},
-			)
+			if not existing_attachment:
+				self.append(
+					"file_association",
+					{"link_doctype": self.attached_to_doctype, "link_name": self.attached_to_name},
+				)
 		if associated_doc and associated_doc != self.name:
 			self.save()
 


### PR DESCRIPTION
Somehow, Frappe allowed a user to attach a file against a doctype, but without storing the exact record ID. For example, the following image has the `attached_to_doctype` set to "Comment", but the `attached_to_name` field is empty:

![image](https://github.com/agritheory/cloud_storage/assets/13396535/15904686-206e-4f07-84bb-e4853e943d57)

This causes an error while trying to save the file:

```python
Traceback (most recent call last):
  File "apps/tas_customizations/tas_customizations/patches/update_file_associations.py", line 35, in execute
    file_doc.save(ignore_permissions=True, ignore_version=True)
  File "apps/frappe/frappe/model/document.py", line 305, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 342, in _save
    self._validate()
  File "apps/frappe/frappe/model/document.py", line 528, in _validate
    self._validate_mandatory()
  File "apps/frappe/frappe/model/document.py", line 863, in _validate_mandatory
    raise frappe.MandatoryError(
frappe.exceptions.MandatoryError: [File, ebc4e91922]: link_name
```

and it can be generally replicated by doing the following in the console:

```python
f = frappe.new_doc("File")
f.file_url = "https://cloud.com/api/method/"
f.attached_to_doctype = "Comment"
f.save()
```