### PR TITLE
fix: set correct data type for permission check

### DIFF
--- a/cloud_storage/cloud_storage/overrides/file.py
+++ b/cloud_storage/cloud_storage/overrides/file.py
@@ -245,7 +245,7 @@ def get_sharing_link(docname: str, reset: str | bool | None = None) -> str:
 	doc = frappe.get_doc("File", docname)
 	if doc.is_private:
 		frappe.has_permission(
-			doctype="File", ptype="share", doc=doc.name, user=frappe.session.user, throw=True
+			doctype="File", ptype="share", doc=doc, user=frappe.session.user, throw=True
 		)
 	if reset or not doc.sharing_link:
 		doc.db_set("sharing_link", str(uuid.uuid4().int >> 64))
@@ -326,7 +326,7 @@ def get_presigned_url(client, key: str):
 
 	if file.is_private:
 		frappe.has_permission(
-			doctype="File", ptype="read", doc=file.name, user=frappe.session.user, throw=True
+			doctype="File", ptype="read", doc=file, user=frappe.session.user, throw=True
 		)
 
 	return client.generate_presigned_url(


### PR DESCRIPTION
```python
File "frappe/app.py", line 66, in application
  response = frappe.api.handle()
File "frappe/api.py", line 54, in handle
  return frappe.handler.handle()
File "frappe/handler.py", line 47, in handle
  data = execute_cmd(cmd)
File "frappe/handler.py", line 85, in execute_cmd
  return frappe.call(method, **frappe.form_dict)
File "__init__.py", line 1608, in call
  return fn(*args, **newargs)
File "cloud_storage/cloud_storage/overrides/file.py", line 426, in retrieve
  signed_url = client.get_presigned_url(key)
File "cloud_storage/cloud_storage/overrides/file.py", line 326, in get_presigned_url
  frappe.has_permission(
File "__init__.py", line 959, in has_permission
  document_label = f"{_(doc.doctype)} {doc.name}" if doc else _(doctype)
AttributeError: 'str' object has no attribute 'doctype'
```