### PR TITLE
fix: allow whitespace in file names

### DIFF
--- a/cloud_storage/cloud_storage/overrides/file.py
+++ b/cloud_storage/cloud_storage/overrides/file.py
@@ -283,7 +283,7 @@ def get_sharing_link(docname: str, reset: Optional[Union[str, bool]] = None) -> 
 
 
 def strip_special_chars(file_name: str) -> str:
-	regex = re.compile("[^0-9a-zA-Z._-]")
+	regex = re.compile(r"[^\w\s_.()-]")
 	return regex.sub("", file_name)
 
 


### PR DESCRIPTION
Problem: Uploading a file with the following characters was implicitly removing them, and causing confusion in the different flows for versioning

- whitespace
- ()