### PR TITLE
[version-15] ci: backport testing (#59)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,13 @@
+{
+	"repoOwner": "agritheory",
+	"repoName": "cloud_storage",
+	"targetBranchChoices": [
+		"version-14",
+		"version-15"
+	],
+	"autoMerge": true,
+	"autoMergeMethod": "squash",
+	"branchLabelMapping": {
+		"^auto-backport-to-(.+)$": "$1"
+	}
+}

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,24 @@
+name: Automatic backport action
+
+on:
+  pull_request_target:
+    types: ["labeled", "closed"]
+
+jobs:
+  backport:
+    name: Backport PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Backport Action
+        uses: sorenlouv/backport-github-action@v9.3.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          auto_backport_label_prefix: backport-to-
+
+      - name: Info log
+        if: ${{ success() }}
+        run: cat ~/.backport/backport.info.log
+        
+      - name: Debug log
+        if: ${{ failure() }}
+        run: cat ~/.backport/backport.debug.log


### PR DESCRIPTION
# Backport

This will backport the following commits from `version-14` to `version-15`:
 - [ci: backport testing (#59)](https://github.com/agritheory/cloud_storage/pull/59)

<!--- Backport version: 9.4.5 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)