### PR TITLE
ci: fix version numbering

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
           - tomli
 
   - repo: https://github.com/agritheory/test_utils
-    rev: v0.15.0
+    rev: v0.16.0
     hooks:
       - id: update_pre_commit_config
       - id: validate_copyright

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
+<!-- Copyright (c) 2024, AgriTheory and contributors
+For license information, please see license.txt-->
+
 # CHANGELOG
 
-## v14.7.2 (2024-08-20)
+## v15.7.2 (2024-08-20)
 
 ### Fix
 

--- a/cloud_storage/__init__.py
+++ b/cloud_storage/__init__.py
@@ -1,4 +1,7 @@
-__version__ = "14.7.0"
+# Copyright (c) 2024, AgriTheory and contributors
+# For license information, please see license.txt
+
+__version__ = "15.7.2"
 
 
 import frappe.desk.form.load

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cloud_storage"
-version = "14.7.2"
+version = "15.7.2"
 description = "Frappe App for integrating with cloud storage applications"
 authors = ["AgriTheory <support@agritheory.dev>"]
 readme = "README.md"
@@ -40,6 +40,9 @@ indent = "\t"
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:tool.poetry.version"]
+version_variable = [
+    "cloud_storage/__init__.py:__version__"
+]
 
 [tool.semantic_release.branches.version]
 match = "version-15"


### PR DESCRIPTION
I noticed running the Newsletter regex (which grabs text from the CHANGELOG.md file for the LLM) that this repo never picked up the `v15.x.x` tag numbering. I created a new release and made tweaks to the CHANGELOG and CI to address.