### PR TITLE
Files cannot be attached from the Library in the add attachements Dialog 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: 'node_modules|.git'
-default_stages: [commit]
+default_stages: [pre-commit]
 fail_fast: false
 
 repos:
@@ -78,7 +78,7 @@ repos:
           - tomli
 
   - repo: https://github.com/agritheory/test_utils
-    rev: v0.16.0
+    rev: v0.17.0
     hooks:
       - id: update_pre_commit_config
       - id: validate_copyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: 'node_modules|.git'
-default_stages: [pre-commit]
+default_stages: [commit]
 fail_fast: false
 
 repos:
@@ -78,7 +78,7 @@ repos:
           - tomli
 
   - repo: https://github.com/agritheory/test_utils
-    rev: v0.17.0
+    rev: v0.16.0
     hooks:
       - id: update_pre_commit_config
       - id: validate_copyright

--- a/cloud_storage/cloud_storage/overrides/file.py
+++ b/cloud_storage/cloud_storage/overrides/file.py
@@ -85,6 +85,14 @@ class CloudStorageFile(File):
 				self.db_set(
 					"file_url", ""
 				)  # this is done to prevent deletion of the remote file with the delete_file hook
+
+				new_association = {
+					"link_doctype": self.attached_to_doctype,
+					"link_name": self.attached_to_name,
+					"user": frappe.session.user,
+					"timestamp": get_datetime(),
+				}
+				
 				rename_doc(
 					self.doctype,
 					self.name,
@@ -95,6 +103,10 @@ class CloudStorageFile(File):
 					ignore_permissions=True,
 					# validate=False,
 				)
+
+				existing_file = frappe.get_doc("File", associated_doc)
+				existing_file.append("file_association", new_association)
+				existing_file.save()
 
 	def on_trash(self) -> None:
 		user_roles = frappe.get_roles(frappe.session.user)
@@ -175,7 +187,7 @@ class CloudStorageFile(File):
 		)
 
 	def remove_file_association(self, dt: str, dn: str) -> None:
-		if len(self.file_association) <= 1:
+		if len(self.file_association) < 1:
 			self.delete()
 			return
 		to_remove = []

--- a/cloud_storage/cloud_storage/overrides/file.py
+++ b/cloud_storage/cloud_storage/overrides/file.py
@@ -85,14 +85,12 @@ class CloudStorageFile(File):
 				self.db_set(
 					"file_url", ""
 				)  # this is done to prevent deletion of the remote file with the delete_file hook
-
 				new_association = {
 					"link_doctype": self.attached_to_doctype,
 					"link_name": self.attached_to_name,
 					"user": frappe.session.user,
 					"timestamp": get_datetime(),
 				}
-				
 				rename_doc(
 					self.doctype,
 					self.name,
@@ -103,7 +101,6 @@ class CloudStorageFile(File):
 					ignore_permissions=True,
 					# validate=False,
 				)
-
 				existing_file = frappe.get_doc("File", associated_doc)
 				existing_file.append("file_association", new_association)
 				existing_file.save()


### PR DESCRIPTION
https://github.com/agritheory/cloud_storage/issues/85


Now, when you add a file from Library, a `file_association` is being created.
Then if the file is removed, the association is removed, only when the file is removed and it doesn't have any `file_association` it's removed from the system.

![Captura de pantalla 2025-05-05 a la(s) 11 46 27 a  m](https://github.com/user-attachments/assets/63abc721-b042-4750-8723-74386f86fafb)
