### PR TITLE
fix: Files are not deleted from S3

### DIFF
--- a/cloud_storage/cloud_storage/overrides/file.py
+++ b/cloud_storage/cloud_storage/overrides/file.py
@@ -233,6 +233,8 @@ class CloudStorageFile(File):
 
 	def remove_file_association(self, dt: str, dn: str) -> None:
 		if len(self.file_association) <= 1:
+			frappe.db.delete("File Association", {"parent": self.name})
+			frappe.db.commit()
 			self.delete()
 			return
 		to_remove = []


### PR DESCRIPTION
Resolves https://github.com/agritheory/cloud_storage/issues/100

The issue occurs because `on_trash` returns early when `self.file_association`is not empty.

`remove_file_association` calls `self.delete()`, but at that point the child table rows still exists.

So before calling `self.delete()`, we now explicitly delete all `self.file_association` records.

