### PR TITLE
fix: ensure CI fails when pytest fails by adding pipefail

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -93,6 +93,7 @@ jobs:
       - name: Run Tests
         working-directory: /home/runner/frappe-bench
         run: |
+          set -o pipefail
           source env/bin/activate
           cd apps/cloud_storage
           poetry install


### PR DESCRIPTION
Bash pipelines (|) return the exit code of the last command by default. By enabling `set -o pipefail`, the pipeline fails if any command fails.

This ensures that the workflow correctly fails when pytest fails.