### PR TITLE
[Fix] Same Filename with Different Content Creates New File

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         additional_dependencies: ['flake8-bugbear']
 
   - repo: https://github.com/agritheory/test_utils
-    rev: v1.20.4
+    rev: v1.25.1
     hooks:
       - id: update_pre_commit_config
       - id: validate_frappe_project

--- a/cloud_storage/cloud_storage/overrides/file.py
+++ b/cloud_storage/cloud_storage/overrides/file.py
@@ -141,8 +141,8 @@ class CloudStorageFile(File):
 					"File Association",
 					{
 						"parent": associated_doc,
-						"link_doctype": self.attached_to_doctype,
-						"link_name": self.attached_to_name,
+						"link_doctype": self.attached_to_doctype,  # type: ignore[has-type]
+						"link_name": self.attached_to_name,  # type: ignore[has-type]
 					},
 				)
 				if not already_associated:

--- a/cloud_storage/cloud_storage/overrides/file.py
+++ b/cloud_storage/cloud_storage/overrides/file.py
@@ -124,7 +124,7 @@ class CloudStorageFile(File):
 				existing_s3_key = frappe.db.get_value("File", associated_doc, "s3_key")
 				if s3_key_from_url and not existing_s3_key:
 					frappe.db.set_value("File", associated_doc, "s3_key", s3_key_from_url)
-					frappe.db.commit()
+
 		elif self.attached_to_doctype and self.attached_to_name and self.file_name:  # type: ignore
 			associated_doc = frappe.db.get_value(
 				"File",

--- a/cloud_storage/cloud_storage/overrides/file.py
+++ b/cloud_storage/cloud_storage/overrides/file.py
@@ -99,10 +99,15 @@ class CloudStorageFile(File):
 					"File",
 					{"content_hash": self.content_hash, "name": ["!=", self.name], "is_folder": False},  # type: ignore
 				)
+			s3_key_from_url = None
 			if associated_doc and associated_doc != self.name:
-				self.db_set(
-					"file_url", ""
-				)  # this is done to prevent deletion of the remote file with the delete_file hook
+				# Extract s3_key from file_url before clearing it; clearing prevents the
+				# delete_file hook from removing the remote object when this duplicate is deleted.
+				if "?key=" in (self.file_url or ""):
+					s3_key_from_url = self.file_url.split("?key=")[1]
+				elif "key=" in (self.file_url or ""):
+					s3_key_from_url = self.file_url.split("key=")[1].split("&")[0]
+				self.db_set("file_url", "")
 				rename_doc(
 					self.doctype,
 					self.name,
@@ -114,13 +119,12 @@ class CloudStorageFile(File):
 					# validate=False,
 				)
 			if associated_doc and not self.s3_key:
-				s3_key = None
-				if "?key=" in self.file_url:
-					s3_key = self.file_url.split("?key=")[1]
-				elif "key=" in self.file_url:
-					s3_key = self.file_url.split("key=")[1].split("&")[0]
-				frappe.db.set_value("File", associated_doc, "s3_key", s3_key)
-				frappe.db.commit()
+				# Only write s3_key onto the existing file when we extracted a valid key from
+				# this duplicate's URL and the existing file does not already have one.
+				existing_s3_key = frappe.db.get_value("File", associated_doc, "s3_key")
+				if s3_key_from_url and not existing_s3_key:
+					frappe.db.set_value("File", associated_doc, "s3_key", s3_key_from_url)
+					frappe.db.commit()
 		elif self.attached_to_doctype and self.attached_to_name and self.file_name:  # type: ignore
 			associated_doc = frappe.db.get_value(
 				"File",
@@ -133,26 +137,45 @@ class CloudStorageFile(File):
 				"name",  # type: ignore
 			)
 			if associated_doc:
-				doc = frappe.get_doc("File", associated_doc)
-				# Merge file associations
-				doc.append(
-					"file_association",
-					add_child_file_association(
-						self.attached_to_doctype,  # type: ignore
-						self.attached_to_name,  # type: ignore
-					),
+				already_associated = frappe.db.exists(
+					"File Association",
+					{
+						"parent": associated_doc,
+						"link_doctype": self.attached_to_doctype,
+						"link_name": self.attached_to_name,
+					},
 				)
-				already_linked = any(version.version == self.content_hash for version in self.versions)
-				if not already_linked:
-					doc.append(
-						"versions",
+				if not already_associated:
+					frappe.get_doc(
 						{
+							"doctype": "File Association",
+							"parent": associated_doc,
+							"parenttype": "File",
+							"parentfield": "file_association",
+							**add_child_file_association(
+								self.attached_to_doctype,  # type: ignore
+								self.attached_to_name,  # type: ignore
+							),
+						}
+					).insert(ignore_permissions=True)
+
+				already_versioned = frappe.db.exists(
+					"File Version",
+					{"parent": associated_doc, "version": self.content_hash},
+				)
+				if not already_versioned:
+					frappe.get_doc(
+						{
+							"doctype": "File Version",
+							"parent": associated_doc,
+							"parenttype": "File",
+							"parentfield": "versions",
 							"version": str(self.content_hash),
 							"user": frappe.session.user,
 							"timestamp": get_datetime(),
-						},
-					)
-				doc.save()
+						}
+					).insert(ignore_permissions=True)
+
 				frappe.delete_doc("File", self.name, ignore_permissions=True)
 
 	def on_trash(self) -> None:
@@ -554,6 +577,8 @@ def upload_file(file: File) -> File:
 	if version_id:
 		file.add_file_version(version_id)
 	file.db_set("s3_key", path)
+	if not file.is_new() and file.content_hash:
+		file.db_set("content_hash", file.content_hash)
 	return file
 
 

--- a/cloud_storage/tests/test_file.py
+++ b/cloud_storage/tests/test_file.py
@@ -196,6 +196,7 @@ def test_file_versioning_with_content_change(mocked_s3_client, example_file_reco
 		frappe.set_user("Administrator")
 		file1 = create_upload_file(example_file_record_5, file_name="sample.csv")
 		assert frappe.db.exists("File", file1.name)
+		original_content_hash = file1.content_hash
 
 		modified_csv = tmp_path / "sample.csv"
 		with open(example_file_record_5) as src, open(modified_csv, "w") as dst:
@@ -206,11 +207,41 @@ def test_file_versioning_with_content_change(mocked_s3_client, example_file_reco
 		file2 = create_upload_file(modified_csv, file_name="sample.csv")
 		file1.load_from_db()
 
+		assert not frappe.db.exists("File", file2.name)
+		assert file1.content_hash == file2.content_hash
+		assert file1.content_hash != original_content_hash
 		assert len(file1.versions) >= 2
 		# Optionally, check that the latest version is the most recent
 		latest_version = file1.versions[-1]
 		assert latest_version.user == "Administrator"
 		assert latest_version.version is not None
+
+
+def test_file_versioning_different_documents(mocked_s3_client, example_file_record_5, tmp_path):
+	"""Same-named file uploaded to two different documents should produce one File record."""
+	with patch(
+		"cloud_storage.cloud_storage.overrides.file.get_cloud_storage_client",
+		return_value=mocked_s3_client,
+	):
+		frappe.set_user("Administrator")
+		file1 = create_upload_file(
+			example_file_record_5, file_name="sample_multi.csv", doctype="User", docname="Administrator"
+		)
+		assert frappe.db.exists("File", file1.name)
+
+		file2 = create_upload_file(
+			example_file_record_5, file_name="sample_multi.csv", doctype="User", docname="Guest"
+		)
+		file1.load_from_db()
+
+		# No duplicate record should exist
+		assert not frappe.db.exists("File", file2.name)
+		# Existing record must keep its s3_key
+		assert file1.s3_key is not None
+		# Both documents should be associated
+		link_doctypes_names = [(fa.link_doctype, fa.link_name) for fa in file1.file_association]
+		assert ("User", "Administrator") in link_doctypes_names
+		assert ("User", "Guest") in link_doctypes_names
 
 
 def test_migration_command(mocked_s3_client, example_file_record_6):


### PR DESCRIPTION
## Summary

Fixes #129 — uploading a file with the same name but updated content left a duplicate `File` record in the database instead of adding a new version to the existing one. The fix also covers a related bug where the S3 key of the original file was silently cleared after re-uploading to a different document.

## Demo

https://github.com/user-attachments/assets/a47eaadf-e9d7-4d5b-9ab6-0a28142954b4


## Tests

Added `test_file_versioning_different_documents`: uploads the same file to two different documents and asserts that only one `File` record exists, the S3 key is preserved, and both documents appear in `file_association`. Also strengthened the existing `test_file_versioning_with_content_change` to assert the canonical file's `content_hash` actually changed after re-upload.
