### PR TITLE
Fix RecursionError for duplicate files

### DIFF
--- a/cloud_storage/__init__.py
+++ b/cloud_storage/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2024, AgriTheory and contributors
 # For license information, please see license.txt
 
-__version__ = "15.7.2"
+__version__ = "15.7.3"
 
 
 import frappe.desk.form.load

--- a/cloud_storage/cloud_storage/overrides/file.py
+++ b/cloud_storage/cloud_storage/overrides/file.py
@@ -53,7 +53,11 @@ class CloudStorageFile(File):
 		PATH: frappe/core/doctype/file/file.py
 		METHOD: validate
 		"""
-		self.associate_files()
+		# `associate_files` can call `.save()` on a duplicate-content File, which re-enters
+		# `validate`. Without this guard, two or more File rows sharing a `content_hash` save
+		# each other in an endless A->B->A loop (maximum recursion depth exceeded).
+		if not self.flags.associating_files:
+			self.associate_files()
 		if self.flags.cloud_storage or self.flags.ignore_file_validate:
 			return
 		if not self.is_remote_file:
@@ -228,10 +232,18 @@ class CloudStorageFile(File):
 			existing_file = frappe.get_doc("File", associated_doc)
 			existing_file.attached_to_doctype = attached_to_doctype
 			existing_file.attached_to_name = attached_to_name
-			existing_file.append(
-				"file_association",
-				add_child_file_association(attached_to_doctype, attached_to_name),
+			already_linked = any(
+				assoc.link_doctype == attached_to_doctype and assoc.link_name == attached_to_name
+				for assoc in existing_file.file_association
 			)
+			if not already_linked:
+				existing_file.append(
+					"file_association",
+					add_child_file_association(attached_to_doctype, attached_to_name),
+				)
+			# Prevent `existing_file.save()` -> `validate` -> `associate_files` from recursing
+			# back into this file (and looping between duplicate-content rows).
+			existing_file.flags.associating_files = True
 			existing_file.save()
 		else:
 			if self.file_association:

--- a/cloud_storage/cloud_storage/overrides/file.py
+++ b/cloud_storage/cloud_storage/overrides/file.py
@@ -53,9 +53,7 @@ class CloudStorageFile(File):
 		PATH: frappe/core/doctype/file/file.py
 		METHOD: validate
 		"""
-		# `associate_files` can call `.save()` on a duplicate-content File, which re-enters
-		# `validate`. Without this guard, two or more File rows sharing a `content_hash` save
-		# each other in an endless A->B->A loop (maximum recursion depth exceeded).
+		# guard against recursion: associate_files() can save another File, re-entering validate
 		if not self.flags.associating_files:
 			self.associate_files()
 		if self.flags.cloud_storage or self.flags.ignore_file_validate:
@@ -241,8 +239,6 @@ class CloudStorageFile(File):
 					"file_association",
 					add_child_file_association(attached_to_doctype, attached_to_name),
 				)
-			# Prevent `existing_file.save()` -> `validate` -> `associate_files` from recursing
-			# back into this file (and looping between duplicate-content rows).
 			existing_file.flags.associating_files = True
 			existing_file.save()
 		else:

--- a/cloud_storage/tests/test_file.py
+++ b/cloud_storage/tests/test_file.py
@@ -89,6 +89,28 @@ def save_file_locally_if_no_cloud_storage(file):
 	return file
 
 
+def raw_file(name, content_hash):
+	"""Insert a File row directly, bypassing validate/associate_files merge-on-insert.
+
+	The normal insert path merges duplicate-content_hash rows into one, we use this
+	to produce the two coexisting duplicate rows required for some tests.
+	"""
+	doc = frappe.get_doc(
+		{
+			"doctype": "File",
+			"file_name": f"{name}.png",
+			"content_hash": content_hash,
+			"file_url": "/api/method/retrieve?key=test_folder/User/Administrator/dup.png",
+			"attached_to_doctype": "User",
+			"attached_to_name": "Administrator",
+			"is_folder": 0,
+		}
+	)
+	doc.name = name
+	doc.db_insert()
+	return doc
+
+
 @mock_s3
 def test_config(get_cloud_storage_client_fixture):
 	c = get_cloud_storage_client_fixture
@@ -242,6 +264,37 @@ def test_file_versioning_different_documents(mocked_s3_client, example_file_reco
 		link_doctypes_names = [(fa.link_doctype, fa.link_name) for fa in file1.file_association]
 		assert ("User", "Administrator") in link_doctypes_names
 		assert ("User", "Guest") in link_doctypes_names
+
+
+@mock_s3
+def test_save_duplicate_content_hash_no_recursion():
+	"""Two File rows sharing a content_hash must not recurse when one is saved."""
+	frappe.set_user("Administrator")
+	content_hash = "deadbeefdeadbeefdeadbeefdeadbeef"
+	file_a = raw_file("test-dup-a", content_hash)
+	raw_file("test-dup-b", content_hash)
+
+	doc = frappe.get_doc("File", file_a.name)
+	doc.save()  # would raise RecursionError before the associating_files guard
+
+	assert frappe.db.exists("File", "test-dup-a")
+	assert frappe.db.exists("File", "test-dup-b")
+
+
+@mock_s3
+def test_associate_files_no_duplicate_association():
+	"""Associating the same link twice must not grow a duplicate file_association row."""
+	frappe.set_user("Administrator")
+	file = raw_file("test-assoc-guard", "assocguardhashassocguardhash0001")
+	before = len(file.file_association)
+
+	file.associate_files("Module Def", "Cloud Storage")
+	after_first = len(file.file_association)
+	file.associate_files("Module Def", "Cloud Storage")
+	after_second = len(file.file_association)
+
+	assert after_first == before + 1
+	assert after_second == after_first  # already_linked guard prevents duplicate
 
 
 def test_migration_command(mocked_s3_client, example_file_record_6):

--- a/cloud_storage/tests/test_file.py
+++ b/cloud_storage/tests/test_file.py
@@ -283,18 +283,24 @@ def test_save_duplicate_content_hash_no_recursion():
 
 @mock_s3
 def test_associate_files_no_duplicate_association():
-	"""Associating the same link twice must not grow a duplicate file_association row."""
+	"""Associating the same link twice must not duplicate the row on the merged file"""
 	frappe.set_user("Administrator")
-	file = raw_file("test-assoc-guard", "assocguardhashassocguardhash0001")
-	before = len(file.file_association)
+	content_hash = "assocguardhashassocguardhash0001"
+	file_a = raw_file("test-assoc-guard-a", content_hash)
+	raw_file("test-assoc-guard-b", content_hash)
 
-	file.associate_files("Module Def", "Cloud Storage")
-	after_first = len(file.file_association)
-	file.associate_files("Module Def", "Cloud Storage")
-	after_second = len(file.file_association)
+	doc = frappe.get_doc("File", file_a.name)
+	doc.associate_files("Module Def", "Cloud Storage")
+	doc.associate_files("Module Def", "Cloud Storage")
 
-	assert after_first == before + 1
-	assert after_second == after_first  # already_linked guard prevents duplicate
+
+	file_b = frappe.get_doc("File", "test-assoc-guard-b")
+	matching = [
+		a
+		for a in file_b.file_association
+		if a.link_doctype == "Module Def" and a.link_name == "Cloud Storage"
+	]
+	assert len(matching) == 1
 
 
 def test_migration_command(mocked_s3_client, example_file_record_6):


### PR DESCRIPTION

Fixes https://github.com/agritheory/cloud_storage/issues/132


1. Guard `associate_files()` behind a flag so a save triggered from within association does not re-run association:

 ```python
 def validate(self):
     # guard against recursion: associate_files() can save another File, re-entering validate
     if not self.flags.associating_files:
         self.associate_files()
     ...
 ```

2. Set the flag before saving the duplicate in `associate_files()`:

```python
existing_file.flags.associating_files = True
existing_file.save()
```

3. Avoid duplicate `file_association` child rows - only append the association if the same `link_doctype` / `link_name` isn't already present:

```python
already_linked = any(
   assoc.link_doctype == attached_to_doctype and assoc.link_name == attached_to_name
   for assoc in existing_file.file_association
)
if not already_linked:
   existing_file.append(
       "file_association",
       add_child_file_association(attached_to_doctype, attached_to_name),
   )
```

This breaks the recursion while still performing the intended one-pass association, and prevents redundant association rows from accumulating.