### PR TITLE
fix: escape literal % in DocShare folder LIKE condition

### DIFF
--- a/cloud_storage/permissions.py
+++ b/cloud_storage/permissions.py
@@ -40,7 +40,7 @@ def docshare_file_condition(user):
 		AND shared_folder.is_folder = 1
 		AND (
 			`tabFile`.folder = shared_folder.name
-			OR `tabFile`.folder LIKE CONCAT(shared_folder.name, '/', '%')
+			OR `tabFile`.folder LIKE CONCAT(shared_folder.name, '/', '%%')
 		)
 	)"""
 	return f"(({direct_share}) OR ({folder_inherit}))"


### PR DESCRIPTION
I ran some tests: everything works fine on version-15, but on version-16 the tests in test_file_permissions.py only pass 1/4:
Error:
```py
query = b"SELECT `name` FROM `tabFile` WHERE `folder`=%(param1)s AND ((((( `tabFile`.`owner` = 'pat.viewer@testcompany.test' )...ONCAT(shared_folder.name, '/', '%')\n\t\t)\n\t))))))) OR (`name` IN (%(param2)s,%(param3)s))) ORDER BY `creation` DESC"
args = {b'param1': b"'Home'", b'param2': b"'60810aa065'", b'param3': b"'Home/DocShare Inherit Folder'"}

    def _mogrify(self, query, args=None):
        """Return query after binding args."""
        db = self._get_db()
    
        if isinstance(query, str):
            query = query.encode(db.encoding)
    
        if args is not None:
            if isinstance(args, dict):
                nargs = {}
                for key, item in args.items():
                    if isinstance(key, str):
                        key = key.encode(db.encoding)
                    nargs[key] = db.literal(item)
                args = nargs
            else:
                args = tuple(map(db.literal, args))
            try:
>               query = query % args # This is where the problem is
```

The only test that passes doesn't use frappe.get_list(), but frappe.has_permission() instead (test: test_shared_user_has_read_permission_on_file)

@agritheory once mentioned that Frappe's get_list method changes between versions. Looking into it in detail:

version-15:
```py
	import frappe.model.db_query

	return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
```

version-16:
```py
	import frappe.model.qb_query

	return frappe.model.qb_query.DatabaseQuery(doctype).execute(*args, **kwargs)
```

Reading the error traceback:

```
../frappe/frappe/__init__.py:1380: in get_list
    return frappe.model.qb_query.DatabaseQuery(doctype).execute(*args, **kwargs)
../frappe/frappe/model/qb_query.py:210: in execute
    result = query.run(debug=debug, as_dict=True, pluck=pluck)
../frappe/frappe/query_builder/utils.py:133: in execute_query
    result = frappe.local.db.sql(query, params, *args, **kwargs)  # nosemgrep
../frappe/frappe/database/database.py:272: in sql
    self.execute_query(query, values)
../frappe/frappe/database/database.py:372: in execute_query
    return self._cursor.execute(query, values)
../../env/lib/python3.14/site-packages/MySQLdb/cursors.py:176: in execute
    mogrified_query = self._mogrify(query, args)
```

The problem happens when `_mogrify()` receives arguments together with a query where we pass a `%`, because it ends up doing something like:

```py
"WHERE folder=%(param1)s AND (folder LIKE CONCAT(x, '/', '%'))" % {"param1": "Home"}
TypeError: not enough arguments for format string
```

That's why the fix that works for both version-15 and version-16 is:

```py
In [1]: "WHERE folder=%(param1)s AND (folder LIKE CONCAT(x, '/', '%%'))" % {"param1": "Home"}
Out[1]: "WHERE folder=Home AND (folder LIKE CONCAT(x, '/', '%'))"
```

With this change, the tests pass on both version-15 and version-16.
