### PR TITLE
test: Automatic cleanup of files uploaded during tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         additional_dependencies: ['flake8-bugbear']
 
   - repo: https://github.com/agritheory/test_utils
-    rev: v1.28.0
+    rev: v1.29.0
     hooks:
       - id: update_pre_commit_config
       - id: validate_frappe_project

--- a/cloud_storage/cloud_storage/overrides/file.py
+++ b/cloud_storage/cloud_storage/overrides/file.py
@@ -46,6 +46,21 @@ class CloudStorageFile(File):
 			return self.file_url.startswith(URL_PREFIXES)  # type: ignore
 		return not self.content
 
+	def validate_file_path(self, path=None):
+		"""
+		HASH: 48366c6ecbad44ed24e6d02bdd8f8f189ce58927
+		REPO: https://github.com/frappe/frappe
+		PATH: frappe/core/doctype/file/file.py
+		METHOD: validate_file_path
+		"""
+		if path is None:
+			if self.is_remote_file:
+				return
+			path = self.get_full_path()
+		base_path = os.path.realpath(get_files_path(is_private=self.is_private))
+		if not os.path.realpath(path).startswith(base_path):
+			frappe.throw(_("The File URL you've entered is incorrect"), title=_("Invalid File URL"))
+
 	def validate(self) -> None:
 		"""
 		HASH: 69a495579a729909f4df7a45855165eee4a208f4
@@ -300,7 +315,7 @@ class CloudStorageFile(File):
 	@frappe.whitelist()
 	def get_content(self) -> bytes:
 		"""
-		HASH: bfbebb3d3d9c26eb34ed447112fcd46f1dadff00
+		HASH: 48366c6ecbad44ed24e6d02bdd8f8f189ce58927
 		REPO: https://github.com/frappe/frappe
 		PATH: frappe/core/doctype/file/file.py
 		METHOD: get_content
@@ -308,6 +323,7 @@ class CloudStorageFile(File):
 		if self.is_folder:
 			frappe.throw(_("Cannot get file contents of a Folder"))
 
+		self.validate_file_path()
 		if self.get("content"):
 			self._content = self.content
 			if self.decode:  # type: ignore
@@ -330,6 +346,7 @@ class CloudStorageFile(File):
 				file_path = frappe.get_site_path("public", "files", self.file_name)
 			else:
 				file_path = frappe.get_site_path("private", "files", self.file_name)
+			self.validate_file_path(file_path)
 			with open(file_path, mode="rb") as f:
 				self._content = f.read()
 				try:

--- a/cloud_storage/cloud_storage/overrides/file.py
+++ b/cloud_storage/cloud_storage/overrides/file.py
@@ -58,7 +58,8 @@ class CloudStorageFile(File):
 				return
 			path = self.get_full_path()
 		base_path = os.path.realpath(get_files_path(is_private=self.is_private))
-		if not os.path.realpath(path).startswith(base_path):
+		resolved_path = os.path.realpath(path)
+		if os.path.commonpath((base_path, resolved_path)) != base_path:
 			frappe.throw(_("The File URL you've entered is incorrect"), title=_("Invalid File URL"))
 
 	def validate(self) -> None:

--- a/cloud_storage/tests/conftest.py
+++ b/cloud_storage/tests/conftest.py
@@ -82,6 +82,26 @@ def patch_frappe_conf(monkeymodule):
 	)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_uploaded_files(db_instance):
+	watched_dirs = [
+		Path(frappe.get_site_path("public", "files")),
+		Path(frappe.get_site_path("private", "files")),
+	]
+	before = {d: (set(d.rglob("*")) if d.is_dir() else set()) for d in watched_dirs}
+
+	yield
+
+	for d in watched_dirs:
+		after = set(d.rglob("*")) if d.is_dir() else set()
+		new_paths = sorted(after - before[d], key=lambda p: len(p.parts), reverse=True)
+		for path in new_paths:
+			if path.is_file():
+				path.unlink(missing_ok=True)
+			elif path.is_dir() and not any(path.iterdir()):
+				path.rmdir()
+
+
 @pytest.fixture
 def mocked_s3_client():
 	with mock_s3():

--- a/cloud_storage/tests/test_local_storage.py
+++ b/cloud_storage/tests/test_local_storage.py
@@ -120,3 +120,27 @@ def test_delete_file_local(example_file):
 	file.delete()
 
 	assert not frappe.db.exists("File", file.name)
+
+
+def test_get_content_rejects_absolute_path_escape():
+	"""An absolute file_name escapes the files/ sandbox via os.path.join."""
+	frappe.set_user("Administrator")
+	file = frappe.new_doc("File")
+	file.file_name = "/etc/hostname"
+	file.file_url = ""
+	file.is_private = 0
+
+	with pytest.raises(frappe.ValidationError):
+		file.get_content()
+
+
+def test_get_content_rejects_relative_path_escape():
+	"""Same escape, via ../ traversal instead of an absolute path."""
+	frappe.set_user("Administrator")
+	file = frappe.new_doc("File")
+	file.file_name = "../" * 10 + "etc/hostname"
+	file.file_url = ""
+	file.is_private = 1
+
+	with pytest.raises(frappe.ValidationError):
+		file.get_content()

--- a/cloud_storage/tests/test_local_storage.py
+++ b/cloud_storage/tests/test_local_storage.py
@@ -144,3 +144,25 @@ def test_get_content_rejects_relative_path_escape():
 
 	with pytest.raises(frappe.ValidationError):
 		file.get_content()
+
+
+def test_get_content_rejects_sibling_directory_escape():
+	"""A sibling dir that merely shares the files/ prefix as a string (files-shadow)
+	must not pass containment just because startswith(base_path) is true."""
+	frappe.set_user("Administrator")
+	shadow_dir = Path(frappe.get_site_path("private")) / "files-shadow"
+	shadow_dir.mkdir(exist_ok=True)
+	secret = shadow_dir / "secret.txt"
+	secret.write_text("outside the sandbox")
+
+	file = frappe.new_doc("File")
+	file.file_name = "../files-shadow/secret.txt"
+	file.file_url = ""
+	file.is_private = 1
+
+	try:
+		with pytest.raises(frappe.ValidationError):
+			file.get_content()
+	finally:
+		secret.unlink()
+		shadow_dir.rmdir()


### PR DESCRIPTION
## Problem

Running the `cloud_storage` test suite more than once in a row (without reinstalling the site in between) causes several tests to start failing.

The cause: tests upload sample files (e.g. `sample.doc`, `diamo.png`) into the site's file folders. Those files stay there after the suite finishes. If `pytest` is run again, Frappe finds a file with that same name already exists and appends a random suffix to avoid overwriting it. Tests that expect the exact file name then fail for that reason, not because anything is actually broken.

## Solution

An automatic cleanup was added that runs on its own at the end of the test suite: before the tests run, it takes a snapshot of which files already exist in the site's file folders, and once the suite finishes it deletes only what appeared during that run, leaving everything that was already there untouched. This way the suite ends up in the same file state it was in before running, and `pytest` can be run as many times as needed without reinstalling the site or cleaning up by hand.

## Fix: path traversal in local `get_content()`

Mirrors upstream's [`1d32c6f7`](https://github.com/frappe/frappe/commit/1d32c6f743608319be9f085fc07e258327450d43) fix, but adapted: `cloud_storage`'s local-disk branch builds its own `file_path` from `self.file_name`, so the one-liner alone didn't block an absolute/`../` escape (see new tests). Added `validate_file_path(self, path=None)` — no-arg call mirrors upstream, explicit `path` validates the local branch's own computed path — and wired it into both spots in `get_content()`.

