### PR TITLE
fix: pasted images in comments and emails render as broken images

### DIFF
--- a/cloud_storage/cloud_storage/overrides/file.py
+++ b/cloud_storage/cloud_storage/overrides/file.py
@@ -149,6 +149,9 @@ class CloudStorageFile(File):
 				if s3_key_from_url and not existing_s3_key:
 					frappe.db.set_value("File", associated_doc, "s3_key", s3_key_from_url)
 
+			if associated_doc and associated_doc != self.name:
+				self.point_at_surviving_file(associated_doc)
+
 		elif self.attached_to_doctype and self.attached_to_name and self.file_name:  # type: ignore
 			associated_doc = frappe.db.get_value(
 				"File",
@@ -201,6 +204,17 @@ class CloudStorageFile(File):
 					).insert(ignore_permissions=True)
 
 				frappe.delete_doc("File", self.name, ignore_permissions=True)
+				self.point_at_surviving_file(associated_doc)
+
+	def point_at_surviving_file(self, surviving_name: str) -> None:
+		"""Repoint this document at the file it was just merged into
+		"""
+		surviving = frappe.db.get_value(
+			"File", surviving_name, ["file_url", "s3_key"], as_dict=True
+		)
+		if surviving:
+			self.file_url = surviving.file_url
+			self.s3_key = surviving.s3_key
 
 	def on_trash(self) -> None:
 		"""

--- a/cloud_storage/cloud_storage/overrides/file.py
+++ b/cloud_storage/cloud_storage/overrides/file.py
@@ -46,6 +46,28 @@ class CloudStorageFile(File):
 			return self.file_url.startswith(URL_PREFIXES)  # type: ignore
 		return not self.content
 
+	@property
+	def unique_url(self) -> str:
+		"""
+		HASH: 69a495579a729909f4df7a45855165eee4a208f4
+		REPO: https://github.com/frappe/frappe
+		PATH: frappe/core/doctype/file/file.py
+		METHOD: unique_url
+
+		Cloud storage file URLs already carry a query string
+		(/api/method/retrieve?key=...), so the fid parameter has to be appended
+		with "&". Core assumes a plain path and always uses "?", which corrupts
+		the key parameter and makes retrieve() return a 404.
+		"""
+		from urllib.parse import urlencode
+
+		file_url = self.file_url or ""
+		if not self.is_private:
+			return file_url
+
+		separator = "&" if "?" in file_url else "?"
+		return file_url + separator + urlencode({"fid": self.name})
+
 	def validate(self) -> None:
 		"""
 		HASH: 69a495579a729909f4df7a45855165eee4a208f4

--- a/cloud_storage/tests/test_file.py
+++ b/cloud_storage/tests/test_file.py
@@ -353,3 +353,52 @@ def test_migration_command(mocked_s3_client, example_file_record_6):
 	assert (
 		s3_file_size == original_file_size
 	), f"File size mismatch: local={original_file_size}, s3={s3_file_size}"
+
+
+def test_unique_url_appends_fid_to_existing_query_string():
+	"""Private cloud storage URLs already have a query string, fid must join with "&".
+
+	Core File.unique_url always uses "?", which produces
+	/api/method/retrieve?key=folder/x.png?fid=<name> and makes retrieve() read
+	"folder/x.png?fid=<name>" as the s3_key, throwing DoesNotExistError. This is
+	the path pasted images in comments and emails take via
+	frappe.core.doctype.file.utils.extract_images_from_html.
+	"""
+	frappe.set_user("Administrator")
+
+	private_file = frappe.get_doc(
+		{
+			"doctype": "File",
+			"file_name": "pasted.png",
+			"file_url": "/api/method/retrieve?key=test_folder/pasted.png",
+			"is_private": 1,
+		}
+	)
+	private_file.name = "test-unique-url-private"
+	assert (
+		private_file.unique_url
+		== "/api/method/retrieve?key=test_folder/pasted.png&fid=test-unique-url-private"
+	)
+
+	public_file = frappe.get_doc(
+		{
+			"doctype": "File",
+			"file_name": "pasted.png",
+			"file_url": "/api/method/retrieve?key=test_folder/pasted.png",
+			"is_private": 0,
+		}
+	)
+	public_file.name = "test-unique-url-public"
+	assert public_file.unique_url == "/api/method/retrieve?key=test_folder/pasted.png"
+
+	# files stored locally keep the core behavior
+	local_file = frappe.get_doc(
+		{
+			"doctype": "File",
+			"file_name": "pasted.png",
+			"file_url": "/private/files/pasted.png",
+			"is_private": 1,
+		}
+	)
+	local_file.name = "test-unique-url-local"
+	assert local_file.unique_url == "/private/files/pasted.png?fid=test-unique-url-local"

--- a/cloud_storage/tests/test_file.py
+++ b/cloud_storage/tests/test_file.py
@@ -402,3 +402,51 @@ def test_unique_url_appends_fid_to_existing_query_string():
 	)
 	local_file.name = "test-unique-url-local"
 	assert local_file.unique_url == "/private/files/pasted.png?fid=test-unique-url-local"
+
+
+def test_duplicate_content_url_points_at_surviving_file(mocked_s3_client):
+	"""Pasting an image whose content already exists must yield a key that is in the bucket.
+
+	The duplicate File is deleted during its own insert by the dedup merge in after_insert,
+	and write_file() never uploads it because it short-circuits on the content hash conflict.
+	frappe.core.doctype.file.utils.extract_images_from_html reads file_url/unique_url off that
+	document afterwards to build the img src, so it has to name the surviving object.
+	"""
+	from PIL import Image
+
+	frappe.set_user("Administrator")
+
+	# an image unique to this test, so the first paste is genuinely new no matter what the
+	# rest of the suite has already uploaded
+	buffer = BytesIO()
+	Image.new("RGB", (7, 11), (13, 57, 199)).save(buffer, format="PNG")
+	content = buffer.getvalue()
+
+	def paste(file_name, attached_to_name):
+		doc = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": file_name,
+				"attached_to_doctype": "User",
+				"attached_to_name": attached_to_name,
+				"content": content,
+				"decode": False,
+				"is_private": 1,
+			}
+		)
+		doc.save(ignore_permissions=True)
+		return doc
+
+	first = paste("dup-paste-first.png", "Administrator")
+	assert frappe.db.exists("File", first.name)
+
+	second = paste("dup-paste-second.png", "Guest")
+
+	# the duplicate is merged into the existing file and deleted during its own insert
+	assert not frappe.db.exists("File", second.name)
+
+	# ...but the URL it hands back must still resolve
+	assert "?key=" in second.file_url
+	key = second.file_url.split("?key=")[1]
+	assert frappe.db.exists("File", {"s3_key": key})
+	assert second.unique_url == f"{second.file_url}&fid={second.name}"


### PR DESCRIPTION

Fixes https://github.com/agritheory/cloud_storage/issues/146

---

- Bug 1: `unique_url` appends `fid` with `?` onto a URL that already has a query string

`frappe.core.doctype.file.utils.extract_images_from_html` saves the pasted image as a `File` and substitutes `_file.unique_url` into the `src`. Core builds that URL assuming `file_url` is a plain path:

```python
return self.file_url + "?" + urlencode({"fid": self.name})
```

Under cloud storage `file_url` is already `/api/method/retrieve?key=<path>`, so the result has two `?`. The second one is a literal inside the query string, and `retrieve()` receives `key = "erp-files/DTcwFj4.png?fid=13783a53be"`. `get_presigned_url` finds no `File` with that `s3_key` and raises `DoesNotExistError`.

**Fix:** override `unique_url` on `CloudStorageFile` and join with `&` when `file_url` already carries a query string. Public files and local `/private/files` paths keep core behaviour.

- Bug 2: pasting an image that already exists stores a key that was never uploaded

With bug 1 fixed, the first paste of an image works, but pasting the same image again (on any document) produces a URL with the correct `&fid=` whose key does not exist in the bucket, and whose `File` does not exist either.

On a content-hash duplicate the incoming `File` is never uploaded and is deleted during its own insert, but `extract_images_from_html` still reads `unique_url` off it afterwards:

1. `associate_files` (called from `validate`) fills an empty `file_url` from the new random file name, i.e. it mints a key before anything exists under it.
2. `write_file` short-circuits on the hash conflict, associates the existing file and returns that document. Nothing is uploaded under the new key. Core calls the hook for its side effects only and discards the return value, so the incoming doc keeps its bogus `file_url`.
3. `after_insert` clears `file_url` in the DB and calls `rename_doc(..., merge=True)`, which deletes the row. Since 15.10.4 it then restores the original `file_url` on the in-memory document so Attach fields do not go blank, which on this path is the never-uploaded key.
4. `extract_images_from_html` reads `unique_url` off the now-deleted doc and writes the dead key into the comment HTML.

`fid` is irrelevant here; `retrieve(key)` resolves purely by `s3_key`.

**Fix:** after the merge, repoint the in-memory document at the surviving file:

```python
def point_at_surviving_file(self, surviving_name: str) -> None:
    surviving = frappe.db.get_value(
        "File", surviving_name, ["file_url", "s3_key"], as_dict=True
    )
    if surviving:
        self.file_url = surviving.file_url
        self.s3_key = surviving.s3_key
```



## Tests

- `test_unique_url_appends_fid_to_existing_query_string`: `fid` joins with `&` for a cloud storage URL, with `?` for a local `/private/files` path, and a public file's `file_url` is returned unchanged.
- `test_duplicate_content_url_points_at_surviving_file`: saving a `File` whose content already exists leaves a `file_url` whose key resolves to a live `File` after the dedup merge. Fails without the fix on 15.10.5 at `assert frappe.db.exists("File", {"s3_key": key})`.


